### PR TITLE
Fixing typo in AWS bucket name.

### DIFF
--- a/devtools/travis-ci/push-docs-to-s3.py
+++ b/devtools/travis-ci/push-docs-to-s3.py
@@ -4,16 +4,13 @@ import tempfile
 import subprocess
 
 
-BUCKET_NAME = 'deechem.io'
+BUCKET_NAME = 'deepchem.io'
 
 if not any(d.project_name == 's3cmd' for d in pip.get_installed_distributions()):
   raise ImportError('The s3cmd pacakge is required. try $ pip install s3cmd')
 
 # The secret key is available as a secure environment variable
 # on travis-ci to push the build documentation to Amazon S3.
-print("Available environment variables:")
-print(os.environ.keys())
-
 with tempfile.NamedTemporaryFile('w') as f:
   f.write('''[default]
 access_key = {AWS_ACCESS_KEY_ID}


### PR DESCRIPTION
Automatic doc pushes almost work. Failed last time due to typo in s3 bucket name.